### PR TITLE
Add borrow semantics to most members of DispatchTable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "dispatchtable"
 version = "0.1.3"
-authors = ["Skarlett <https://github.com/Skarlett>"]
+authors = [
+    "Skarlett <https://github.com/Skarlett>",
+    "Foobles <https://github.com/theInkSquid>"
+]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,27 +1,52 @@
-pub trait DispatchFunction<P, R>: Fn(&P) -> R + 'static + Sync + Send
-where
-    P: Send + Sync {}
+use std::borrow::Borrow;
+use std::hash::Hash;
 
-impl<T, P, R> DispatchFunction<P, R> for T
-where 
-  T: Fn(&P) -> R + 'static + Sync + Send, 
-  P: Send + Sync {}
-
-pub trait Dispatcher<K, P, R> 
+pub trait DispatchFunction<P: ?Sized, R>: Fn(&P) -> R + 'static + Sync + Send
 where
-    K: std::cmp::Eq
+    P: Send + Sync,
 {
-    fn into_vec(self) -> Vec<(K, Box<dyn DispatchFunction<P, R>> )>;
-    fn remove(&mut self, key: &K);
+}
+
+impl<T, P: ?Sized, R> DispatchFunction<P, R> for T
+where
+    T: Fn(&P) -> R + 'static + Sync + Send,
+    P: Send + Sync,
+{
+}
+
+pub trait Dispatcher<K, P: ?Sized, R>
+where
+    K: Eq + Hash,
+{
+    fn into_vec(self) -> Vec<(K, Box<dyn DispatchFunction<P, R>>)>;
+
+    fn remove<Q: ?Sized>(&mut self, key: &Q)
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash;
+
     fn insert(&mut self, key: K, item: Box<dyn DispatchFunction<P, R>>);
-    fn contains_key(&self, key: &K) -> bool;
-    fn get(&self, key: &K) -> Option<&Box<dyn DispatchFunction<P, R>>>;
+
+    fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash;
+
+    fn get<Q: ?Sized>(&self, key: &Q) -> Option<&Box<dyn DispatchFunction<P, R>>>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash;
+
     fn len(&self) -> usize;
-    
-    fn call(&self, key: &K, params: &P) -> Option<R> {
+
+    fn call<Q: ?Sized>(&self, key: &Q, params: &P) -> Option<R>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash,
+    {
         match self.get(key) {
             Some(func) => Some(func(params)),
-            None => None            
+            None => None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,67 +1,79 @@
-//! dispatchtable is a runtime key based collection that contains references to functions. 
+//! dispatchtable is a runtime key based collection that contains references to functions.
 //!
 //! # Quick Start
 //! ```
 //! use dispatchtable::{Dispatch, DispatchTable};
-//! 
+//!
 //! fn add(p: &(u8, u8)) -> u8 { p.0 + p.1 }
 //! fn sub(p: &(u8, u8)) -> u8 { p.0 - p.1 }
-//! 
+//!
 //! fn main() {
-//!   let dispatchtable = DispatchTable::new();
-//! 
-//!   dispatchtable.insert("add", Box::new(add));
-//!   dispatchtable.insert("sub", Box::new(sub));
-//! 
+//!   let mut dispatchtable = DispatchTable::new();
+//!
+//!   dispatchtable.insert("add".to_string(), Box::new(add));
+//!   dispatchtable.insert("sub".to_string(), Box::new(sub));
+//!
 //!   assert_eq!(dispatchtable.call("sub", &(10, 5)), Some(5));
 //! }
 //! ```
 
-
-
+mod core;
 #[cfg(test)]
 mod test;
-mod core;
 
-use std::collections::HashMap;
 pub use crate::core::{DispatchFunction, Dispatcher as Dispatch};
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::hash::Hash;
 
-pub struct DispatchTable<K, P, R> {
-    inner: HashMap<K, Box<dyn DispatchFunction<P, R>>>
+pub struct DispatchTable<K, P: ?Sized, R> {
+    inner: HashMap<K, Box<dyn DispatchFunction<P, R>>>,
 }
 
-impl<K, P, R> DispatchTable<K, P, R> {
+impl<K: Hash + Eq, P: ?Sized, R> DispatchTable<K, P, R> {
     pub fn new() -> Self {
         Self {
-            inner: HashMap::new()
+            inner: HashMap::new(),
         }
     }
 }
 
-impl<K, P, R> Dispatch<K, P, R> for DispatchTable<K, P, R>
+impl<K, P: ?Sized, R> Dispatch<K, P, R> for DispatchTable<K, P, R>
 where
-    K: std::hash::Hash + std::cmp::Eq
-{   
+    K: std::hash::Hash + std::cmp::Eq,
+{
     fn len(&self) -> usize {
         self.inner.len()
     }
 
-    fn contains_key(&self, key: &K) -> bool {
+    fn contains_key<Q: ?Sized>(&self, key: &Q) -> bool
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash,
+    {
         self.inner.contains_key(key)
     }
 
-    fn remove(&mut self, key: &K) {
+    fn remove<Q: ?Sized>(&mut self, key: &Q)
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash,
+    {
         self.inner.remove(key);
     }
     fn insert(&mut self, key: K, item: Box<dyn DispatchFunction<P, R>>) {
         self.inner.insert(key, item);
     }
 
-    fn get(&self, key: &K) -> Option<&Box<dyn DispatchFunction<P, R>>> {
+    fn get<Q: ?Sized>(&self, key: &Q) -> Option<&Box<dyn DispatchFunction<P, R>>>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash,
+    {
         self.inner.get(key)
     }
 
-    fn into_vec(self) -> Vec<(K, Box<dyn DispatchFunction<P, R>> )> {
+    fn into_vec(self) -> Vec<(K, Box<dyn DispatchFunction<P, R>>)> {
         self.inner.into_iter().collect()
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,21 +1,21 @@
-use crate::DispatchTable;
 use crate::Dispatch;
+use crate::DispatchTable;
 
-fn greet(params: &String) -> String {
+fn greet(params: &str) -> String {
     let mut greeting = String::from("Hello ");
-    greeting.push_str(&**params);
+    greeting.push_str(params);
     greeting
 }
 
-fn echo(params: &String) -> String {
-    params.clone()
+fn echo(params: &str) -> String {
+    params.to_string()
 }
 
 fn lifetime_test<'a>(params: &(&'a [u8],)) -> &'a [u8] {
     params.0
 }
 
-fn bound_lifetime<'a, 'b: 'a>(params: &(&'a [u8], &'b [u8])) -> (&'a [u8], &'b [u8]){
+fn bound_lifetime<'a, 'b: 'a>(params: &(&'a [u8], &'b [u8])) -> (&'a [u8], &'b [u8]) {
     *params
 }
 
@@ -24,13 +24,10 @@ fn expected_output() {
     let mut map = DispatchTable::new();
     map.insert("greet", Box::new(greet));
     map.insert("echo", Box::new(echo));
-    
+
+    assert_eq!(map.call(&"echo", "asd").unwrap(), String::from("asd"));
     assert_eq!(
-        map.call(&"echo", &String::from("asd")).unwrap(),
-        String::from("asd")
-    );
-    assert_eq!(
-        map.call(&"greet", &String::from("Skarlett")).unwrap(),
+        map.call(&"greet", "Skarlett").unwrap(),
         String::from("Hello Skarlett")
     );
 }
@@ -52,4 +49,14 @@ fn accepts_bound_lifetimes() {
     let (a, b) = map.call(&"lifetime", &(buf, &buf[1..3])).unwrap();
     assert_eq!(buf, a);
     assert_eq!(b, b"if");
+}
+
+#[test]
+fn has_proper_borrow_semantics() {
+    let mut map = DispatchTable::new();
+    map.insert("foo".to_string(), Box::new(echo));
+    assert_eq!(map.call("foo", "Hello").unwrap(), String::from("Hello"));
+    let _x = map.get("foo");
+    map.remove(&"abc".to_string());
+    let _b = map.contains_key("bar");
 }


### PR DESCRIPTION
This change makes most methods of DispatchTable that used to take `&K` now accept `&Q`, where `K: Borrow<Q>`. This allows for a `DispatchTable<String, V>` to be indexed by a `str`, for example.

This also adds the `P: ?Sized` trait bound for DispatchFunction (and all related uses of P), since it is only ever used through references.